### PR TITLE
Use `window` if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
     root.Code128Generator = previous_Code128Generator
     return Code128Generator
   }
-}).call(this);
+}).call(typeof window !== 'undefined' ? window : this);
 
 function Code128Generator(){
   var codes=[


### PR DESCRIPTION
For browser and Node.js support `this` was referenced. However, this doesn't work in React Native where `window` is defined but `this` isn't.

Fixes #13
